### PR TITLE
Fix sign-in freeze by bounding password mask to prevent buffer overflow

### DIFF
--- a/3d-jelly/3ds/source/ui.c
+++ b/3d-jelly/3ds/source/ui.c
@@ -181,9 +181,14 @@ AuthResult ui_draw_auth(UiContext *ctx) {
     u32 pass_col = (s_auth_field == 1) ? COL_SELECTED : COL_SURFACE;
     draw_rounded_rect(60, 150, 280, 35, pass_col);
     draw_text(ctx->font, "Password", 70, 157, 0.38f, COL_TEXT_DIM);
-    /* Show dots for password */
+    /* Show masked password without overflowing the render buffer */
     char pass_dots[64] = "";
-    for (int i = 0; s_auth_pass[i]; i++) strcat(pass_dots, "•");
+    size_t pass_len = strlen(s_auth_pass);
+    if (pass_len >= sizeof(pass_dots)) {
+        pass_len = sizeof(pass_dots) - 1;
+    }
+    memset(pass_dots, '*', pass_len);
+    pass_dots[pass_len] = '\0';
     draw_text(ctx->font, pass_dots[0] ? pass_dots : "tap to enter...", 70, 170, 0.45f,
               pass_dots[0] ? COL_TEXT : COL_TEXT_DIM);
     


### PR DESCRIPTION
### Motivation
- Prevent the app from freezing after entering credentials by fixing unsafe password masking that could overflow a fixed render buffer when masking long passwords.

### Description
- In `ui_draw_auth` (in `3ds/source/ui.c`) replace repeated UTF-8 bullet concatenation with a bounded mask: compute `strlen(s_auth_pass)`, cap it to the mask buffer size, fill with single-byte `'*'`, and always null-terminate before rendering.

### Testing
- Verified the source change and that the masked buffer is now size-bounded and null-terminated by inspecting the modified `ui_draw_auth` code; confirmed the patch was applied to `3ds/source/ui.c` and no other files were modified; a full 3DS build was not executed in this environment due to lack of a build invocation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a64ac0071c832f8de63166d191d94b)