### PR TITLE
Fix sign-in freeze caused by password mask buffer overflow

### DIFF
--- a/3d-jelly/3ds/source/ui.c
+++ b/3d-jelly/3ds/source/ui.c
@@ -181,9 +181,14 @@ AuthResult ui_draw_auth(UiContext *ctx) {
     u32 pass_col = (s_auth_field == 1) ? COL_SELECTED : COL_SURFACE;
     draw_rounded_rect(60, 150, 280, 35, pass_col);
     draw_text(ctx->font, "Password", 70, 157, 0.38f, COL_TEXT_DIM);
-    /* Show dots for password */
+    /* Show masked password safely.
+     * Avoid UTF-8 bullet concatenation here because each "•" is 3 bytes and can
+     * overflow the fixed 64-byte buffer for longer passwords. */
     char pass_dots[64] = "";
-    for (int i = 0; s_auth_pass[i]; i++) strcat(pass_dots, "•");
+    size_t pass_len = strnlen(s_auth_pass, sizeof(s_auth_pass));
+    size_t mask_len = pass_len < (sizeof(pass_dots) - 1) ? pass_len : (sizeof(pass_dots) - 1);
+    memset(pass_dots, '*', mask_len);
+    pass_dots[mask_len] = '\0';
     draw_text(ctx->font, pass_dots[0] ? pass_dots : "tap to enter...", 70, 170, 0.45f,
               pass_dots[0] ? COL_TEXT : COL_TEXT_DIM);
     


### PR DESCRIPTION
### Motivation
- Prevent a sign-in freeze caused by memory corruption when masking the password: the previous code appended the UTF-8 bullet `"•"` repeatedly into a fixed 64-byte buffer which could overflow for longer passwords.

### Description
- Replace the unsafe `strcat("•")` loop with a bounded mask generator that uses `strnlen` to measure the password, caps the mask to the buffer size, fills the mask with `memset('*', ...)`, and explicitly null-terminates before drawing.

### Testing
- Ran repository sanity checks (`git add`/`git commit`, `git diff --check HEAD~1..HEAD`, `git status`) which passed, and did not run a runtime/build test because the 3DS toolchain/runtime is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a64ac0071c832f8de63166d191d94b)