### PR TITLE
Perform async server discovery/auth in worker threads and fix password masking

### DIFF
--- a/3d-jelly/3ds/source/main.c
+++ b/3d-jelly/3ds/source/main.c
@@ -82,6 +82,50 @@ static void handle_state_settings(void);
 static void set_error(const char *msg);
 static void transition_to(AppState new_state);
 
+/* Async network helpers to keep UI responsive while requests are in-flight. */
+typedef struct {
+    ApiContext *api;
+    char username[64];
+    char password[64];
+    ApiAuthResponse auth;
+    int rc;
+    volatile int done;
+} AuthJob;
+
+typedef struct {
+    ServerDiscoveryResult result;
+    int rc;
+    volatile int done;
+} DiscoveryJob;
+
+static void auth_worker_thread(void *arg);
+static void discovery_worker_thread(void *arg);
+static void draw_loading_frame(const char *base_msg);
+
+static void auth_worker_thread(void *arg) {
+    AuthJob *job = (AuthJob *)arg;
+    job->rc = api_authenticate(job->api, job->username, job->password, &job->auth);
+    job->done = 1;
+}
+
+static void discovery_worker_thread(void *arg) {
+    DiscoveryJob *job = (DiscoveryJob *)arg;
+    job->rc = api_discover_servers(&job->result);
+    job->done = 1;
+}
+
+static void draw_loading_frame(const char *base_msg) {
+    char msg[96];
+    u64 now = osGetTime();
+    int dots = (int)((now / 350) % 4);
+    snprintf(msg, sizeof(msg), "%s%.*s", base_msg, dots, "...");
+
+    C3D_FrameBegin(C3D_FRAME_SYNCDRAW);
+    ui_draw_splash(g_app.ui, msg);
+    ui_render_frame(g_app.ui);
+    C3D_FrameEnd(0);
+}
+
 /* ── Entry Point ─────────────────────────────────────────────────────────── */
 int main(int argc, char *argv[]) {
     (void)argc; (void)argv;
@@ -191,13 +235,33 @@ static void handle_state_discover(void) {
 
     /* Trigger UDP scan on first entry */
     if (!g_app.ui->discovery_done) {
-        ui_draw_splash(g_app.ui, "Scanning for Jellyfin servers...");
-        C3D_FrameEnd(0);
+        DiscoveryJob job;
+        memset(&job, 0, sizeof(job));
 
-        /* Do the actual UDP broadcast scan */
-        api_discover_servers(&g_app.ui->discovery);
-        g_app.ui->discovery_done = 1;
-        g_app.ui->discovery_sel  = 0;
+        Thread t = threadCreate(discovery_worker_thread, &job, 16 * 1024,
+                                0x18, -1, false);
+        if (!t) {
+            ui_show_toast(g_app.ui, "Discovery thread failed", 2500);
+            return;
+        }
+
+        C3D_FrameEnd(0);
+        while (aptMainLoop() && !job.done) {
+            hidScanInput();
+            draw_loading_frame("Scanning for Jellyfin servers");
+        }
+
+        threadJoin(t, U64_MAX);
+        C3D_FrameBegin(C3D_FRAME_SYNCDRAW);
+        threadFree(t);
+
+        if (job.rc == 0) {
+            g_app.ui->discovery = job.result;
+            g_app.ui->discovery_done = 1;
+            g_app.ui->discovery_sel = 0;
+        } else {
+            ui_show_toast(g_app.ui, "Discovery failed", 2500);
+        }
         return;
     }
 
@@ -240,20 +304,33 @@ static void handle_state_auth(void) {
     }
 
     if (result.done) {
-        /* Draw loading screen BEFORE the blocking HTTP call.
-         * Without this the GPU gets no frames during the request and freezes. */
-        C3D_FrameEnd(0);
-        C3D_FrameBegin(C3D_FRAME_SYNCDRAW);
-        ui_draw_splash(g_app.ui, "Signing in...");
-        C3D_FrameEnd(0);
-        C3D_FrameBegin(C3D_FRAME_SYNCDRAW);
+        AuthJob job;
+        memset(&job, 0, sizeof(job));
+        job.api = g_app.api;
+        strncpy(job.username, result.username, sizeof(job.username) - 1);
+        strncpy(job.password, result.password, sizeof(job.password) - 1);
 
-        ApiAuthResponse auth;
-        int rc = api_authenticate(g_app.api, result.username, result.password, &auth);
-        if (rc == 0) {
-            strncpy(g_app.token,    auth.token,    sizeof(g_app.token) - 1);
-            strncpy(g_app.user_id,  auth.user_id,  sizeof(g_app.user_id) - 1);
-            strncpy(g_app.username, auth.username, sizeof(g_app.username) - 1);
+        Thread t = threadCreate(auth_worker_thread, &job, 16 * 1024,
+                                0x18, -1, false);
+        if (!t) {
+            ui_show_toast(g_app.ui, "Sign-in thread failed", 2500);
+            return;
+        }
+
+        C3D_FrameEnd(0);
+        while (aptMainLoop() && !job.done) {
+            hidScanInput();
+            draw_loading_frame("Signing in");
+        }
+
+        threadJoin(t, U64_MAX);
+        C3D_FrameBegin(C3D_FRAME_SYNCDRAW);
+        threadFree(t);
+
+        if (job.rc == 0) {
+            strncpy(g_app.token,    job.auth.token,    sizeof(g_app.token) - 1);
+            strncpy(g_app.user_id,  job.auth.user_id,  sizeof(g_app.user_id) - 1);
+            strncpy(g_app.username, job.auth.username, sizeof(g_app.username) - 1);
 
             strncpy(g_app.config->token,    g_app.token,    sizeof(g_app.config->token) - 1);
             strncpy(g_app.config->user_id,  g_app.user_id,  sizeof(g_app.config->user_id) - 1);
@@ -263,7 +340,7 @@ static void handle_state_auth(void) {
             transition_to(STATE_HOME);
         } else {
             char err[64];
-            snprintf(err, sizeof(err), "Login failed (error %d)", rc);
+            snprintf(err, sizeof(err), "Login failed (error %d)", job.rc);
             ui_show_toast(g_app.ui, err, 3000);
         }
     }

--- a/3d-jelly/3ds/source/ui.c
+++ b/3d-jelly/3ds/source/ui.c
@@ -181,9 +181,14 @@ AuthResult ui_draw_auth(UiContext *ctx) {
     u32 pass_col = (s_auth_field == 1) ? COL_SELECTED : COL_SURFACE;
     draw_rounded_rect(60, 150, 280, 35, pass_col);
     draw_text(ctx->font, "Password", 70, 157, 0.38f, COL_TEXT_DIM);
-    /* Show dots for password */
+    /* Show masked password safely.
+     * Avoid UTF-8 bullet concatenation here because each "•" is 3 bytes and can
+     * overflow the fixed 64-byte buffer for longer passwords. */
     char pass_dots[64] = "";
-    for (int i = 0; s_auth_pass[i]; i++) strcat(pass_dots, "•");
+    size_t pass_len = strnlen(s_auth_pass, sizeof(s_auth_pass));
+    size_t mask_len = pass_len < (sizeof(pass_dots) - 1) ? pass_len : (sizeof(pass_dots) - 1);
+    memset(pass_dots, '*', mask_len);
+    pass_dots[mask_len] = '\0';
     draw_text(ctx->font, pass_dots[0] ? pass_dots : "tap to enter...", 70, 170, 0.45f,
               pass_dots[0] ? COL_TEXT : COL_TEXT_DIM);
     


### PR DESCRIPTION
### Motivation

- Keep the UI responsive during blocking network operations so the GPU continues rendering while discovery/auth requests run. 
- Prevent UI freezes during `api_discover_servers` and `api_authenticate` calls by moving them off the main thread. 
- Avoid potential buffer overflow and multi-byte concatenation issues when rendering the password field on the auth screen.

### Description

- Added `AuthJob` and `DiscoveryJob` structs and worker thread functions `auth_worker_thread` and `discovery_worker_thread` to perform `api_authenticate` and `api_discover_servers` asynchronously. 
- Introduced `draw_loading_frame` to render an animated loading message while worker threads are in-flight and integrated thread creation/join logic into `handle_state_discover` and `handle_state_auth` using `threadCreate`, `threadJoin`, and `threadFree`. 
- Updated `handle_state_discover` to populate `g_app.ui->discovery` from the discovery job result and show a toast on failure. 
- Updated `handle_state_auth` to use the auth job result and propagate `job.auth` into `g_app` and `g_app.config`, and show a failure toast using the job return code. 
- Reworked password masking in `ui_draw_auth` to safely build a fixed-size masked string (using `*`) and avoid concatenating UTF-8 bullet characters which could overflow the password buffer.

### Testing

- Performed an automated project build with `make` for the 3DS target and the build completed successfully. 
- No automated unit tests were present for these code paths in the repository, so changes were validated via the successful build and the integrated smoke tests in the runtime environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a64ac0071c832f8de63166d191d94b)