### PR TITLE
Start with Jellyfin-style server picker and keep session on same server

### DIFF
--- a/3d-jelly/3ds/source/main.c
+++ b/3d-jelly/3ds/source/main.c
@@ -82,6 +82,50 @@ static void handle_state_settings(void);
 static void set_error(const char *msg);
 static void transition_to(AppState new_state);
 
+/* Async network helpers to keep UI responsive while requests are in-flight. */
+typedef struct {
+    ApiContext *api;
+    char username[64];
+    char password[64];
+    ApiAuthResponse auth;
+    int rc;
+    volatile int done;
+} AuthJob;
+
+typedef struct {
+    ServerDiscoveryResult result;
+    int rc;
+    volatile int done;
+} DiscoveryJob;
+
+static void auth_worker_thread(void *arg);
+static void discovery_worker_thread(void *arg);
+static void draw_loading_frame(const char *base_msg);
+
+static void auth_worker_thread(void *arg) {
+    AuthJob *job = (AuthJob *)arg;
+    job->rc = api_authenticate(job->api, job->username, job->password, &job->auth);
+    job->done = 1;
+}
+
+static void discovery_worker_thread(void *arg) {
+    DiscoveryJob *job = (DiscoveryJob *)arg;
+    job->rc = api_discover_servers(&job->result);
+    job->done = 1;
+}
+
+static void draw_loading_frame(const char *base_msg) {
+    char msg[96];
+    u64 now = osGetTime();
+    int dots = (int)((now / 350) % 4);
+    snprintf(msg, sizeof(msg), "%s%.*s", base_msg, dots, "...");
+
+    C3D_FrameBegin(C3D_FRAME_SYNCDRAW);
+    ui_draw_splash(g_app.ui, msg);
+    ui_render_frame(g_app.ui);
+    C3D_FrameEnd(0);
+}
+
 /* ── Entry Point ─────────────────────────────────────────────────────────── */
 int main(int argc, char *argv[]) {
     (void)argc; (void)argv;
@@ -129,18 +173,13 @@ static void app_init(void) {
     /* Give player the UI's top-screen render target (not a new duplicate one) */
     player_set_render_target(g_app.player, g_app.ui->top);
 
-    /* Initial state */
-    if (!g_app.config->setup_complete || !g_app.config->jellyfin_host[0]) {
-        /* First run — go to discovery screen */
-        g_app.state = STATE_DISCOVER;
-    } else if (!g_app.config->token[0]) {
-        g_app.state = STATE_AUTH;
-    } else {
+    /* Initial state: always begin at server picker (Jellyfin-style server selection). */
+    if (g_app.config->token[0]) {
         strncpy(g_app.token,    g_app.config->token,    sizeof(g_app.token) - 1);
         strncpy(g_app.user_id,  g_app.config->user_id,  sizeof(g_app.user_id) - 1);
         strncpy(g_app.username, g_app.config->username, sizeof(g_app.username) - 1);
-        g_app.state = STATE_HOME;
     }
+    g_app.state = STATE_DISCOVER;
 }
 
 /* ── Main Loop ───────────────────────────────────────────────────────────── */
@@ -191,13 +230,33 @@ static void handle_state_discover(void) {
 
     /* Trigger UDP scan on first entry */
     if (!g_app.ui->discovery_done) {
-        ui_draw_splash(g_app.ui, "Scanning for Jellyfin servers...");
-        C3D_FrameEnd(0);
+        DiscoveryJob job;
+        memset(&job, 0, sizeof(job));
 
-        /* Do the actual UDP broadcast scan */
-        api_discover_servers(&g_app.ui->discovery);
-        g_app.ui->discovery_done = 1;
-        g_app.ui->discovery_sel  = 0;
+        Thread t = threadCreate(discovery_worker_thread, &job, 16 * 1024,
+                                0x18, -1, false);
+        if (!t) {
+            ui_show_toast(g_app.ui, "Discovery thread failed", 2500);
+            return;
+        }
+
+        C3D_FrameEnd(0);
+        while (aptMainLoop() && !job.done) {
+            hidScanInput();
+            draw_loading_frame("Scanning for Jellyfin servers");
+        }
+
+        threadJoin(t, U64_MAX);
+        C3D_FrameBegin(C3D_FRAME_SYNCDRAW);
+        threadFree(t);
+
+        if (job.rc == 0) {
+            g_app.ui->discovery = job.result;
+            g_app.ui->discovery_done = 1;
+            g_app.ui->discovery_sel = 0;
+        } else {
+            ui_show_toast(g_app.ui, "Discovery failed", 2500);
+        }
         return;
     }
 
@@ -205,19 +264,27 @@ static void handle_state_discover(void) {
     int done = ui_draw_discovery(g_app.ui, g_app.config);
 
     if (done) {
+        /* Keep auth session only if user picked the same server as before. */
+        int same_server = (strcmp(g_app.config->jellyfin_host, g_app.api->host) == 0) &&
+                          (g_app.config->jellyfin_port == g_app.api->port);
+
         /* Update API context with selected server */
         api_set_server(g_app.api,
                        g_app.config->jellyfin_host,
                        g_app.config->jellyfin_port);
         g_app.config->setup_complete = 1;
-        config_save(g_app.config, CONFIG_PATH);
 
-        /* Clear any cached token — go back to login */
-        memset(g_app.config->token,   0, sizeof(g_app.config->token));
-        memset(g_app.config->user_id, 0, sizeof(g_app.config->user_id));
-        config_save(g_app.config, CONFIG_PATH);
+        if (!same_server) {
+            memset(g_app.token,           0, sizeof(g_app.token));
+            memset(g_app.user_id,         0, sizeof(g_app.user_id));
+            memset(g_app.username,        0, sizeof(g_app.username));
+            memset(g_app.config->token,   0, sizeof(g_app.config->token));
+            memset(g_app.config->user_id, 0, sizeof(g_app.config->user_id));
+            memset(g_app.config->username,0, sizeof(g_app.config->username));
+        }
 
-        transition_to(STATE_AUTH);
+        config_save(g_app.config, CONFIG_PATH);
+        transition_to(g_app.config->token[0] ? STATE_HOME : STATE_AUTH);
     }
 
     /* SELECT on discovery screen goes back to manual entry */
@@ -240,20 +307,33 @@ static void handle_state_auth(void) {
     }
 
     if (result.done) {
-        /* Draw loading screen BEFORE the blocking HTTP call.
-         * Without this the GPU gets no frames during the request and freezes. */
-        C3D_FrameEnd(0);
-        C3D_FrameBegin(C3D_FRAME_SYNCDRAW);
-        ui_draw_splash(g_app.ui, "Signing in...");
-        C3D_FrameEnd(0);
-        C3D_FrameBegin(C3D_FRAME_SYNCDRAW);
+        AuthJob job;
+        memset(&job, 0, sizeof(job));
+        job.api = g_app.api;
+        strncpy(job.username, result.username, sizeof(job.username) - 1);
+        strncpy(job.password, result.password, sizeof(job.password) - 1);
 
-        ApiAuthResponse auth;
-        int rc = api_authenticate(g_app.api, result.username, result.password, &auth);
-        if (rc == 0) {
-            strncpy(g_app.token,    auth.token,    sizeof(g_app.token) - 1);
-            strncpy(g_app.user_id,  auth.user_id,  sizeof(g_app.user_id) - 1);
-            strncpy(g_app.username, auth.username, sizeof(g_app.username) - 1);
+        Thread t = threadCreate(auth_worker_thread, &job, 16 * 1024,
+                                0x18, -1, false);
+        if (!t) {
+            ui_show_toast(g_app.ui, "Sign-in thread failed", 2500);
+            return;
+        }
+
+        C3D_FrameEnd(0);
+        while (aptMainLoop() && !job.done) {
+            hidScanInput();
+            draw_loading_frame("Signing in");
+        }
+
+        threadJoin(t, U64_MAX);
+        C3D_FrameBegin(C3D_FRAME_SYNCDRAW);
+        threadFree(t);
+
+        if (job.rc == 0) {
+            strncpy(g_app.token,    job.auth.token,    sizeof(g_app.token) - 1);
+            strncpy(g_app.user_id,  job.auth.user_id,  sizeof(g_app.user_id) - 1);
+            strncpy(g_app.username, job.auth.username, sizeof(g_app.username) - 1);
 
             strncpy(g_app.config->token,    g_app.token,    sizeof(g_app.config->token) - 1);
             strncpy(g_app.config->user_id,  g_app.user_id,  sizeof(g_app.config->user_id) - 1);
@@ -263,7 +343,7 @@ static void handle_state_auth(void) {
             transition_to(STATE_HOME);
         } else {
             char err[64];
-            snprintf(err, sizeof(err), "Login failed (error %d)", rc);
+            snprintf(err, sizeof(err), "Login failed (error %d)", job.rc);
             ui_show_toast(g_app.ui, err, 3000);
         }
     }

--- a/3d-jelly/3ds/source/ui.c
+++ b/3d-jelly/3ds/source/ui.c
@@ -181,9 +181,14 @@ AuthResult ui_draw_auth(UiContext *ctx) {
     u32 pass_col = (s_auth_field == 1) ? COL_SELECTED : COL_SURFACE;
     draw_rounded_rect(60, 150, 280, 35, pass_col);
     draw_text(ctx->font, "Password", 70, 157, 0.38f, COL_TEXT_DIM);
-    /* Show dots for password */
+    /* Show masked password safely.
+     * Avoid UTF-8 bullet concatenation here because each "•" is 3 bytes and can
+     * overflow the fixed 64-byte buffer for longer passwords. */
     char pass_dots[64] = "";
-    for (int i = 0; s_auth_pass[i]; i++) strcat(pass_dots, "•");
+    size_t pass_len = strnlen(s_auth_pass, sizeof(s_auth_pass));
+    size_t mask_len = pass_len < (sizeof(pass_dots) - 1) ? pass_len : (sizeof(pass_dots) - 1);
+    memset(pass_dots, '*', mask_len);
+    pass_dots[mask_len] = '\0';
     draw_text(ctx->font, pass_dots[0] ? pass_dots : "tap to enter...", 70, 170, 0.45f,
               pass_dots[0] ? COL_TEXT : COL_TEXT_DIM);
     
@@ -700,7 +705,8 @@ int ui_draw_discovery(UiContext *ctx, Config *config) {
             draw_text(ctx->font, "Manual entry...", 18, y + 8, 0.48f, COL_ACCENT);
         }
     }
-    draw_text(ctx->font, "A:Select  UP/DOWN:Navigate  X:Rescan", 10, 226, 0.35f, COL_TEXT_DIM);
+    draw_text(ctx->font, "A:Select  UP/DOWN:Navigate  X:Rescan", 10, 218, 0.35f, COL_TEXT_DIM);
+    draw_text(ctx->font, "START: Use saved server", 10, 230, 0.35f, COL_TEXT_DIM);
     C2D_TargetClear(ctx->bottom, COL_BG);
     C2D_SceneBegin(ctx->bottom);
     draw_text_centered(ctx->font, "3D Jelly", 30, 320, 0.7f, COL_PRIMARY);
@@ -719,8 +725,9 @@ int ui_draw_discovery(UiContext *ctx, Config *config) {
         ctx->discovery_done = 0;
         ctx->discovery_sel  = 0;
         memset(&ctx->discovery, 0, sizeof(ctx->discovery));
-        api_discover_servers(&ctx->discovery);
-        ctx->discovery_done = 1;
+    }
+    if (keys & KEY_START && config->jellyfin_host[0]) {
+        return 1;
     }
     if (keys & KEY_A) {
         if (ctx->discovery_sel < disc->count) {


### PR DESCRIPTION
## Summary
- changed app startup to always open the server discovery/selection screen first
- added a `START: Use saved server` shortcut on the discovery UI so users can immediately continue with their configured server
- updated discovery flow to preserve cached auth only when the selected server matches the current API host/port, and clear auth when switching servers
- removed blocking discovery call from `ui_draw_discovery` rescan path; rescan now defers to the async discovery handler

## Why
Users requested Jellyfin-like startup behavior where server selection is available at launch and loading feels intentional rather than frozen.

## Testing
- `git -C /workspace/3d-jelly diff --check`
- `git -C /workspace/3d-jelly status --short`
- static verification only; no 3DS runtime in this environment

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a64ac0071c832f8de63166d191d94b)